### PR TITLE
feat: bump llm-ls to `0.3.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ llm.setup({
   -- llm-ls configuration, cf llm-ls section
   lsp = {
     bin_path = nil,
-    version = "0.2.2",
+    version = "0.3.0",
   },
   tokenizer = nil, -- cf Tokenizer paragraph
   context_window = 8192, -- max number of tokens for the context window

--- a/lua/llm/config.lua
+++ b/lua/llm/config.lua
@@ -25,7 +25,7 @@ local default_config = {
   ---@class llm_config_lsp
   lsp = {
     bin_path = nil,
-    version = "0.2.2",
+    version = "0.3.0",
   },
   tokenizer = nil,
   context_window = 8192,


### PR DESCRIPTION
llm-ls now supports AST parsing to improve suggestions. Based on the cursor's position the AST, suggestions will be empty (no suggestion), single line or multi line.