### PR TITLE
Allow environment variables to be passed

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ When developing locally, when using mason or if you built your own binary becaus
 
 `lsp.version` is used only when **llm.nvim** downloads **llm-ls** from the release page.
 
-`lsp.cmd_env` can be used to set environment variables to be used for llm-ls. Currently only `LLM_LOG_LEVEL` might be useful.
+`lsp.cmd_env` can be used to set environment variables for the **llm-ls** process.
 
 #### Mason
 

--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ When developing locally, when using mason or if you built your own binary becaus
 
 `lsp.version` is used only when **llm.nvim** downloads **llm-ls** from the release page.
 
+`lsp.cmd_env` can be used to set environment variables to be used for llm-ls. Currently only `LLM_LOG_LEVEL` might be useful.
+
 #### Mason
 
 You can install **llm-ls** via [mason.nvim](https://github.com/williamboman/mason.nvim). To do so, run the following command:
@@ -333,6 +335,7 @@ llm.setup({
     bin_path = nil,
     host = nil,
     port = nil,
+    cmd_env = nil, -- or { LLM_LOG_LEVEL = "DEBUG" } to set the log level of llm-ls
     version = "0.5.3",
   },
   tokenizer = nil, -- cf Tokenizer paragraph

--- a/lua/llm/config.lua
+++ b/lua/llm/config.lua
@@ -29,6 +29,7 @@ local default_config = {
     bin_path = nil,
     host = nil,
     port = nil,
+    cmd_env = nil,
     version = "0.5.3",
   },
   tokenizer = nil,

--- a/lua/llm/language_server.lua
+++ b/lua/llm/language_server.lua
@@ -205,6 +205,7 @@ function M.setup()
   local client_id = lsp.start_client({
     name = "llm-ls",
     cmd = cmd,
+    cmd_env = config.get().lsp.cmd_env,
     root_dir = vim.fs.dirname(vim.fs.find({ ".git" }, { upward = true })[1]),
   })
 


### PR DESCRIPTION
In order to set environment variable only to the LSP server, this set cmd_env from config if available.

Reference: https://neovim.io/doc/user/lsp.html#vim.lsp.ClientConfig

---

Example usage: See below example lazy.vim plugin configuration. with cmd_env, I can set log_level at the plugin config, instead of global environment.

```lua
local M = {
  'blmarket/llm.nvim',
  opts = {
    model = "gemma-7b-it-q4f16_2-MLC",
    backend = "openai",
    url = "http://127.0.0.1:8000/v1/completions",
    lsp = {
      bin_path = vim.fn.expand("$HOME/proj/llm-ls/target/release/llm-ls"),
      cmd_env = {
        LLM_LOG_LEVEL = "DEBUG",
      },
      version = "0.5.2",
    },
    fim = {
      enabled = false,
    },
    context_window = 1024,
    enable_suggestions_on_startup = true,
  },
}

return M
```