### PR TITLE
Use vim.lsp.start_client instead of vim.lsp.start

### DIFF
--- a/lua/llm/language_server.lua
+++ b/lua/llm/language_server.lua
@@ -202,7 +202,7 @@ function M.setup()
     cmd = { llm_ls_path }
   end
 
-  local client_id = lsp.start({
+  local client_id = lsp.start_client({
     name = "llm-ls",
     cmd = cmd,
     root_dir = vim.fs.dirname(vim.fs.find({ ".git" }, { upward = true })[1]),


### PR DESCRIPTION
Starting from neovim 0.10, vim.lsp.start will return nil if there's no buf specified for attachment. As llm.nvim will handle the buf attachment by itself, it's okay to use `start_client` instead of `start`

Reference:

- Neovim 0.9 implementation return client_id regardless of attachment: https://github.com/neovim/neovim/blob/release-0.9/runtime/lua/vim/lsp.lua#L889
- Neovim 0.10 starts to return nil, which caused llm.nvim to fail: https://github.com/neovim/neovim/blob/89dc8f8f4e754e70cbe1624f030fb61bded41bc2/runtime/lua/vim/lsp.lua#L274

Testing:

Checked neovim 0.10 / 0.9.5 shows proper suggestion with the fix