### PR TITLE
feat(config): add default request body per backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,10 @@ Refer to Ollama's documentation on how to run ollama. Here is an example configu
   model = "codellama",
   url = "http://localhost:8000", -- llm-ls uses "/v1/completions"
   -- cf https://github.com/abetlen/llama-cpp-python?tab=readme-ov-file#openai-compatible-web-server
-  request_body = {}
+  request_body = {
+    temperature = 0.2,
+    top_p = 0.95,
+  }
 }
 ```
 

--- a/lua/llm/config.lua
+++ b/lua/llm/config.lua
@@ -39,6 +39,16 @@ local default_config = {
   disable_url_path_completion = false,
 }
 
+local default_request_bodies = {
+  ollama = {
+    options = {
+      temperature = 0.2,
+      top_p = 0.95,
+    },
+  },
+  openai = {},
+}
+
 local M = {
   config = nil,
 }
@@ -71,6 +81,15 @@ function M.setup(opts)
   end
 
   local config = vim.tbl_deep_extend("force", default_config, opts or {})
+
+  if config.backend ~= "huggingface" and config.backend ~= "tgi" then
+    local def_req_body = default_request_bodies[config.backend] or {}
+    if opts and opts.request_body ~= nil then
+      config.request_body = vim.tbl_deep_extend("force", def_req_body, opts.request_body)
+    else
+      config.request_body = def_req_body
+    end
+  end
 
   if config.api_token == nil then
     config.api_token = M.get_token()

--- a/lua/llm/config.lua
+++ b/lua/llm/config.lua
@@ -46,7 +46,10 @@ local default_request_bodies = {
       top_p = 0.95,
     },
   },
-  openai = {},
+  openai = {
+    temperature = 0.2,
+    top_p = 0.95,
+  },
 }
 
 local M = {


### PR DESCRIPTION
This PR adds default request bodies for the `ollama` and `openai` backends that match the current README. It also tweaks the `setup` function to merge the user-supplied request body with the default request body for the matching backend when using a backend other than `huggingface` or `tgi` in order to avoid passing invalid parameters to the backend.

Closes #87 