### PR TITLE
ci(#96): added tag-PR and commitlint workflows

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,15 @@
+name: commitlint
+
+on: [pull_request]
+
+jobs:
+  lint-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: npm install --save-dev @commitlint/{cli,config-conventional}
+      - run: |
+          echo "module.exports = { extends: ['@commitlint/config-conventional'] };" > commitlint.config.js
+      - run: npx commitlint --from HEAD~1 --to HEAD --verbose

--- a/.github/workflows/tag-conflicts.yml
+++ b/.github/workflows/tag-conflicts.yml
@@ -1,0 +1,23 @@
+name: Tag PRs with merge conflicts
+
+on:
+  # So that PRs touching the same files as the push are updated
+  push:
+  # So that the `dirtyLabel` is removed if conflicts are resolve
+  # We recommend `pull_request_target` so that github secrets are available.
+  # In `pull_request` we wouldn't be able to change labels of fork PRs
+  pull_request_target:
+    types: [synchronize]
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: check if prs are dirty
+        uses: eps1lon/actions-label-merge-conflict@releases/2.x
+        with:
+          dirtyLabel: conflicts
+          removeOnDirtyLabel: conflicts
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          commentOnDirty: "⚠️ This PR has conflicts. Please, solve them."
+          commentOnClean: "✅ The conflict have been solved! Ready to review."


### PR DESCRIPTION
# Changes made

- [x] Added commitlint to check [conventional commit rules](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Added tag `conflicts` to PR that have conflicts so it notifies the people on that PR