### PR TITLE
fix (keymaps): Prevent key press cancellation when no completions available

### DIFF
--- a/lua/llm/keymaps.lua
+++ b/lua/llm/keymaps.lua
@@ -6,14 +6,14 @@ local M = {
 }
 
 local function accept_suggestion()
-  if not completion.suggestion then
+  if not completion.suggestion or not completion.shown_suggestion then
     return config.get().accept_keymap
   end
   vim.schedule(completion.complete)
 end
 
 local function dismiss_suggestion()
-  if not completion.suggestion then
+  if not completion.suggestion or not completion.shown_suggestion then
     return config.get().dismiss_keymap
   end
   vim.schedule(function()

--- a/lua/llm/keymaps.lua
+++ b/lua/llm/keymaps.lua
@@ -7,14 +7,14 @@ local M = {
 
 local function accept_suggestion()
   if not completion.suggestion then
-    return
+    return config.get().accept_keymap
   end
   vim.schedule(completion.complete)
 end
 
 local function dismiss_suggestion()
   if not completion.suggestion then
-    return
+    return config.get().dismiss_keymap
   end
   vim.schedule(function()
     completion.cancel()


### PR DESCRIPTION
# Description

With the current keymaps setup, pressing the accept/dismiss key (e.g `<Tab>`, `<S-Tab>`) does not have any effect if there are no completion suggestions available. This effectively "cancels" the keypress and can be confusing/annoying for users.

For example, in inset mode, when using `<Tab>` as the accept key, if no completions are available, the tab key becomes inactive.

This PR addresses this issue by ensuring that pressing the accept/dismiss key always falls back to the original keypress when there are no completions

## Changes
- [keymaps](lua/llm/keymaps.lua) — Modified `accept_suggestion` and `dismiss_suggestion` functions to fallback to the original keypress when no completions exists.
- [keymaps](lua/llm/keymaps.lua) — _Same functions as above_. Ensured that completion could not be accepted unless shown to the user.