### PR TITLE
Add aarch64 to arch_map

### DIFF
--- a/lua/llm/language_server.lua
+++ b/lua/llm/language_server.lua
@@ -20,6 +20,7 @@ local function build_binary_name()
     x86_64 = "x86_64",
     i686 = "i686",
     arm64 = "aarch64",
+    aarch64 = "aarch64",
   }
 
   local os_map = {


### PR DESCRIPTION
There is '[LLM] Unsupported architecture or OS' error in build_binary_name() for Linux aarch64. Tested on Ubuntu aarch64 VM