### PR TITLE
Add default config for LlamaCPP backend

### DIFF
--- a/lua/llm/config.lua
+++ b/lua/llm/config.lua
@@ -51,7 +51,10 @@ local default_request_bodies = {
     temperature = 0.2,
     top_p = 0.95,
   },
-  llamacpp = {},
+  llamacpp = {
+    tmperature = 0.2,
+    top_p = 0.95,
+  },
 }
 
 local M = {


### PR DESCRIPTION
When the user does not specify a config section in their opts, then there is no default config to fall back to, and an error is thrown.