### PR TITLE
feat(config): accept to run llm-ls in PATH

### DIFF
--- a/lua/llm/language_server.lua
+++ b/lua/llm/language_server.lua
@@ -191,7 +191,7 @@ function M.setup()
   local port = config.get().lsp.port
   if host ~= nil and port ~= nil then
     cmd = lsp.rpc.connect(host, port)
-  elseif vim.fn.executable(bin_path) == 0 then
+  elseif fn.executable(bin_path) == 0 then
     local llm_ls_path = download_llm_ls()
     if llm_ls_path == nil then
       vim.notify("[LLM] failed to download llm-ls", vim.log.levels.ERROR)

--- a/lua/llm/language_server.lua
+++ b/lua/llm/language_server.lua
@@ -75,10 +75,6 @@ local function download_and_unzip(url, path)
 end
 
 local function download_llm_ls()
-  local bin_path = config.get().lsp.bin_path
-  if bin_path ~= nil and fn.filereadable(bin_path) == 1 then
-    return bin_path
-  end
   local bin_dir = vim.api.nvim_call_function("stdpath", { "data" }) .. "/llm_nvim/bin"
   fn.system("mkdir -p " .. bin_dir)
   local bin_name = build_binary_name()
@@ -185,15 +181,17 @@ function M.setup()
     return
   end
 
-  local cmd
   local host = config.get().lsp.host
+  local bin_path = config.get().lsp.bin_path or "llm-ls"
+  local cmd = { bin_path }
+
   if host == "localhost" then
     host = "127.0.0.1"
   end
   local port = config.get().lsp.port
   if host ~= nil and port ~= nil then
     cmd = lsp.rpc.connect(host, port)
-  else
+  elseif vim.fn.executable(bin_path) == 0 then
     local llm_ls_path = download_llm_ls()
     if llm_ls_path == nil then
       vim.notify("[LLM] failed to download llm-ls", vim.log.levels.ERROR)

--- a/lua/llm/language_server.lua
+++ b/lua/llm/language_server.lua
@@ -181,9 +181,9 @@ function M.setup()
     return
   end
 
+  local cmd
   local host = config.get().lsp.host
   local bin_path = config.get().lsp.bin_path or "llm-ls"
-  local cmd = { bin_path }
 
   if host == "localhost" then
     host = "127.0.0.1"
@@ -198,6 +198,8 @@ function M.setup()
       return
     end
     cmd = { llm_ls_path }
+  else
+    cmd = { bin_path }
   end
 
   local client_id = lsp.start_client({


### PR DESCRIPTION
It's uncommon to completely ignore PATH. I have llm-ls installed via my package manager, and the downloaded one wouldn't work anyway. If bin_path is not set, llm.nvim will try to start llm-ls from PATH, else fallback to config.lsp.bin_path. Note that we dont check The 'version' of llm-ls so it's possible for the plugin to run a version that doesn't match the one configured (for instance if you've added it after the first run of llm.nvim). A version check could/should be added later.