### PR TITLE
Add passthrough for accept and dismiss keymaps

### DIFF
--- a/lua/llm/keymaps.lua
+++ b/lua/llm/keymaps.lua
@@ -5,21 +5,25 @@ local M = {
   setup_done = false,
 }
 
-local function accept_suggestion()
-  if not completion.suggestion then
-    return
+local function accept_suggestion(keys)
+  return function()
+    if not completion.suggestion then
+      return vim.api.nvim_replace_termcodes(keys, true, true, true)
+    end
+    vim.schedule(completion.complete)
   end
-  vim.schedule(completion.complete)
 end
 
-local function dismiss_suggestion()
-  if not completion.suggestion then
-    return
+local function dismiss_suggestion(keys)
+  return function()
+    if not completion.suggestion then
+      return vim.api.nvim_replace_termcodes(keys, true, true, true)
+    end
+    vim.schedule(function()
+      completion.cancel()
+      completion.suggestion = nil
+    end)
   end
-  vim.schedule(function()
-    completion.cancel()
-    completion.suggestion = nil
-  end)
 end
 
 function M.setup()
@@ -30,13 +34,14 @@ function M.setup()
   local accept_keymap = config.get().accept_keymap
   local dismiss_keymap = config.get().dismiss_keymap
 
-  vim.keymap.set("i", accept_keymap, accept_suggestion, { expr = true })
+  local accept_func = accept_suggestion(accept_keymap)
+  local dismiss_func = dismiss_suggestion(dismiss_keymap)
 
-  vim.keymap.set("n", accept_keymap, accept_suggestion, { expr = true })
+  vim.keymap.set("i", accept_keymap, accept_func, { expr = true })
+  vim.keymap.set("n", accept_keymap, accept_func, { expr = true })
 
-  vim.keymap.set("i", dismiss_keymap, dismiss_suggestion, { expr = true })
-
-  vim.keymap.set("n", dismiss_keymap, dismiss_suggestion, { expr = true })
+  vim.keymap.set("i", dismiss_keymap, dismiss_func, { expr = true })
+  vim.keymap.set("n", dismiss_keymap, dismiss_func, { expr = true })
 
   M.setup_done = true
 end


### PR DESCRIPTION
This allows passing the original expression through for keymaps. This should fix people who want to use their accept binding for something else when there is no suggestion. I use `<C-F>` for moving my cursor forwards, but also to accept (just like in Fish shell), so having `llm.nvim` take over `<C-F>` was a no-go for me.

Fixes #61 